### PR TITLE
Add support for indented code blocks, fixes #8

### DIFF
--- a/formatter/src/test/kotlin/org/kotlin/formatter/output/KDocFormatterTest.kt
+++ b/formatter/src/test/kotlin/org/kotlin/formatter/output/KDocFormatterTest.kt
@@ -585,6 +585,106 @@ internal class KDocFormatterTest {
     }
 
     @Test
+    fun `leaves preformatted indented code blocks as is`() {
+        val subject = KDocFormatter(maxLineLength = 50)
+
+        val result = subject.format(
+            """
+            |    Some code
+            |    Some more code
+            """.trimMargin()
+        )
+
+        assertThat(result).isEqualTo(
+            """
+            |    Some code
+            |    Some more code
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `leaves whitespace in preformatted indented code blocks as is`() {
+        val subject = KDocFormatter(maxLineLength = 50)
+
+        val result = subject.format(
+            """
+            |    Some code
+            |
+            |    Some more code
+            """.trimMargin()
+        )
+
+        assertThat(result).isEqualTo(
+            """
+            |    Some code
+            |
+            |    Some more code
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `does not handle preformatted indented code blocks immediately preceded by paragraphs`() {
+        val subject = KDocFormatter(maxLineLength = 50)
+
+        val result = subject.format(
+            """
+            |A paragraph which is long enough that the text should wrap.
+            |    Some code
+            """.trimMargin()
+        )
+
+        assertThat(result).isEqualTo(
+            """
+            |A paragraph which is long enough that the text
+            |should wrap. Some code
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `handles paragraph following preformatted indented code blocks`() {
+        val subject = KDocFormatter(maxLineLength = 50)
+
+        val result = subject.format(
+            """
+            |    Some code
+            |A paragraph which is long enough that the text should wrap.
+            """.trimMargin()
+        )
+
+        assertThat(result).isEqualTo(
+            """
+            |    Some code
+            |A paragraph which is long enough that the text
+            |should wrap.
+            """.trimMargin()
+        )
+    }
+
+    @Test
+    fun `preserves a blank line following a preformatted indented code block`() {
+        val subject = KDocFormatter(maxLineLength = 50)
+
+        val result = subject.format(
+            """
+                |    Some code
+                |
+                |A paragraph.
+            """.trimMargin()
+        )
+
+        assertThat(result).isEqualTo(
+            """
+                |    Some code
+                |
+                |A paragraph.
+            """.trimMargin()
+        )
+    }
+
+    @Test
     fun `formats within block quotes`() {
         val subject = KDocFormatter(maxLineLength = 12)
 


### PR DESCRIPTION
As specified by the [Darling Fireball Markdown Syntax](https://daringfireball.net/projects/markdown/syntax#precode).